### PR TITLE
fix(position_cost_type_options): hide tax rate field when cost type i…

### DIFF
--- a/src/coda/apps/invoices/views/inspect.py
+++ b/src/coda/apps/invoices/views/inspect.py
@@ -222,14 +222,18 @@ def _try_pay(invoice: Invoice, request: HttpRequest) -> None:
 @login_required
 def position_cost_type_options(request: HttpRequest) -> HttpResponse:
     counter = request.GET.get("counter")
-    cost_type_key = f"positions-{counter}-cost_type"
+    cost_type_key = f"positions-{counter}-item-cost_type"
     cost_type = request.GET.get(cost_type_key)
     if cost_type == "vat":
         return HttpResponse("")
+
+    tax_rate_key = f"positions-{counter}-tax_rate"
+    tax_rate = request.GET.get(tax_rate_key, DEFAULT_TAX_RATE_PERCENTAGE)
+
     return render(
         request,
         "invoices/position_tax_rate.html",
-        {"counter": counter, "tax_rate": DEFAULT_TAX_RATE_PERCENTAGE},
+        {"counter": counter, "tax_rate": tax_rate},
     )
 
 

--- a/src/coda/apps/templates/invoices/position_generic_partial.html
+++ b/src/coda/apps/templates/invoices/position_generic_partial.html
@@ -36,7 +36,7 @@
                 hx-target="#tax-rate-wrapper-{{ counter }}"
                 hx-swap="innerHTML"
                 hx-trigger="change"
-                hx-include="[name='positions-{{ counter }}-item-cost_type']"
+                hx-include="[name='positions-{{ counter }}-item-cost_type'], [name='positions-{{ counter }}-tax_rate']"
                 hx-vals='{"counter": "{{ counter }}"}'>
             {% if position.type == "contract" %}
                 {% for type in contract_cost_types %}

--- a/tests/invoices/test_cost_type_htmx_views.py
+++ b/tests/invoices/test_cost_type_htmx_views.py
@@ -1,0 +1,31 @@
+from django.test import Client
+from django.urls import reverse
+import pytest
+
+from coda.domain.finance.costtypes import PublicationCostType
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("logged_in")
+def test__changing_cost_type_to_vat__has_no_tax_rate_field(client: Client) -> None:
+    response = client.get(
+        reverse("invoices:position_cost_type_options"),
+        data={"counter": "1", "positions-1-item-cost_type": PublicationCostType.Vat.value},
+    )
+
+    assert response.content == b""
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("logged_in")
+def test__changing_cost_type__keeps_entered_tax_rate(client: Client) -> None:
+    response = client.get(
+        reverse("invoices:position_cost_type_options"),
+        data={
+            "counter": "1",
+            "positions-1-item-cost_type": PublicationCostType.Publication_Charge.value,
+            "positions-1-tax_rate": "85",
+        },
+    )
+
+    assert response.context["tax_rate"] == "85"


### PR DESCRIPTION
…s vat. keep tax rate between non-vat cost type changes

Fixes #191 and #173 