### PR TITLE
fix: add missing auth guards to monograph update, HTMX formsets, and institution views

### DIFF
--- a/src/coda/apps/fundingrequests/views/wizard/update_monograph.py
+++ b/src/coda/apps/fundingrequests/views/wizard/update_monograph.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpRequest
 from django.urls import reverse
 
@@ -20,7 +21,7 @@ from coda.domain.contract import PublisherId
 
 
 @breadcrumb("Update Publication Details", parent_url_name="fundingrequests:detail")
-class MonographUpdateMetaView(Wizard):
+class MonographUpdateMetaView(LoginRequiredMixin, Wizard):
     store_name = "monograph_request_update_meta"
     steps = [PublicationStep.for_monograph(), PublisherStep()]
     store_factory = SessionStore

--- a/src/coda/apps/htmx_components/forms.py
+++ b/src/coda/apps/htmx_components/forms.py
@@ -6,6 +6,7 @@ from typing import Any, Generic, Self, TypeVar
 
 import pydantic
 from django import forms
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
 from django.utils.datastructures import MultiValueDict
@@ -264,7 +265,7 @@ class HtmxDynamicFormset(Generic[FormType]):
         return self.render()
 
 
-class ManagementView(View, Generic[FormType]):
+class ManagementView(LoginRequiredMixin, View, Generic[FormType]):
     name: str
     form_class: type[FormType]
     add_button: bool = True

--- a/src/coda/apps/institutions/views.py
+++ b/src/coda/apps/institutions/views.py
@@ -202,6 +202,7 @@ def institution_detail(request: HttpRequest, pk: int) -> HttpResponse:
     )
 
 
+@login_required
 @require_GET
 def request_set_successor(request: HttpRequest, pk: int) -> HttpResponse:
     institution = get_object_or_404(Institution.objects, pk=pk)
@@ -222,6 +223,7 @@ def request_set_successor(request: HttpRequest, pk: int) -> HttpResponse:
     )
 
 
+@login_required
 @require_GET
 def request_delete_institution(request: HttpRequest, pk: int) -> HttpResponse:
     institution = get_object_or_404(Institution.objects, pk=pk)


### PR DESCRIPTION
Adds missing authentication guards to 7 routes that were accessible without login.


| Route | Methods | Data Exposed |
|-------|---------|-------------|
| `/fundingrequests/update/monograph/<pk>/meta` | GET, POST | Read & write: title, authors, license, links, publisher, contracts |
| `/fundingrequests/partial/contract/` | POST | Write: formset state (add/remove contract rows) |
| `/fundingrequests/partial/external-funding/` | POST | Write: formset state (add/remove external funding rows) |
| `/contracts/partial/entity-form/` | POST | Write: formset state (add/remove entity rows) |
| `/authors/partial/author-formset/` | POST | Write: formset state (add/remove author rows) |
| `/institutions/<pk>/request-set-successor/` | GET | Read: institution name, all other institutions, home institution status, child count |
| `/institutions/<pk>/request-delete/` | GET | Read: institution name, deletion eligibility, blocking reasons |


- Formset endpoints and institution views were called only from already-authenticated parent pages. No impact on legitimate workflows
- Monograph update view was fully exposed. Any unauthenticated user could read and permanently overwrite metadata for any monograph via guessable `<pk>`
- All 7 production `Wizard` subclasses now have `LoginRequiredMixin`