### PR TITLE
fix: disallow GET on HTMX delete endpoints, remove dead block_journal view

### DIFF
--- a/src/coda/apps/fundingrequests/views/funders.py
+++ b/src/coda/apps/fundingrequests/views/funders.py
@@ -6,7 +6,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse_lazy
-from django.views.decorators.http import require_GET, require_POST
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from django.views.generic import CreateView, UpdateView
 
 from coda.apps.fundingrequests.forms import ExternalFundingFormset
@@ -70,6 +70,7 @@ fundingorganizations_update = FundingOrganizationUpdateView.as_view()
 
 
 @login_required
+@require_http_methods(["DELETE", "POST"])
 def fundingorganizations_delete(request: HttpRequest, pk: int) -> HttpResponse:
     fundingorganization = get_object_or_404(FundingOrganization, pk=pk)
     fundingorganization.delete()

--- a/src/coda/apps/fundingrequests/views/labels.py
+++ b/src/coda/apps/fundingrequests/views/labels.py
@@ -5,7 +5,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_http_methods, require_POST
 from django.views.generic import CreateView, UpdateView
 
 from coda.apps.fundingrequests.forms import LabelForm
@@ -55,6 +55,7 @@ label_list_view = LabelListView.as_view()
 
 
 @login_required
+@require_http_methods(["DELETE", "POST"])
 def label_delete_view(request: HttpRequest, pk: int) -> HttpResponse:
     label = get_object_or_404(Label, pk=pk)
     label.delete()

--- a/src/coda/apps/journals/views.py
+++ b/src/coda/apps/journals/views.py
@@ -1,10 +1,10 @@
-from typing import Any, cast
+from typing import Any
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.urls import reverse_lazy
 from django.utils.safestring import mark_safe
@@ -83,17 +83,6 @@ class JournalUpdateView(LoginRequiredMixin, UpdateView[Journal, JournalForm]):
 
 
 journal_update_view = JournalUpdateView.as_view()
-
-
-@login_required
-def block_journal(request: HttpRequest, pk: int) -> HttpResponse:
-    reason = request.POST.get("reason", "PREDATORY")
-    journal = get_object_or_404(Journal, pk=pk)
-
-    blocklist = BlockList.objects.get()
-    blocklist.block_journal(journal, reason)
-
-    return cast(HttpResponse, journal_detail_view(request, eissn=journal.eissn))
 
 
 @login_required


### PR DESCRIPTION
Three small fixes addressing CSRF bypass vectors where state-changing views accepted GET requests (which skip Django's CSRF token validation):

1. fix(fundingrequests/labels): disallow GET on label delete. label_delete_view was called via hx-delete but had no method restriction. A GET to the same URL would delete a label without CSRF validation. Restricted to DELETE/POST.
2. fix(fundingrequests/funders): disallow GET on funder delete. Same pattern. fundingorganizations_delete had no method restriction. Restricted to DELETE/POST. (*The template button is currently commented out, but the route is live.*)
3. fix(journals): remove dead block_journal view. `journals/views.py` contained a second block_journal function that was unreachable (no URL routed to it). The routed version at `blocklist/views.py:59` already has `@require_POST`. Deleted the dead code, cleaned up unused imports.