### PR TITLE
fix(fundingrequest/dto): fix float imprecision for monetary amounts

### DIFF
--- a/src/coda/apps/dto.py
+++ b/src/coda/apps/dto.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Annotated, Any, TypeVar
 
 from pydantic import BaseModel, BeforeValidator
@@ -22,7 +23,7 @@ def to_post_data(
 ) -> dict[str, Any]:
     return {
         _build_key(k, prefix, underscores_to_dash): _to_json(v)
-        for k, v in model.model_dump(mode="json", exclude=exclude).items()
+        for k, v in model.model_dump(mode="python", exclude=exclude).items()
     }
 
 
@@ -40,6 +41,9 @@ def _build_key(key: str, prefix: str = "", underscores_to_dash: bool = False) ->
 def _to_json(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return to_post_data(value)
+
+    if isinstance(value, Decimal):
+        return str(value)
 
     if isinstance(value, dict):
         value = {k: v if v is not None else "" for k, v in value.items()}

--- a/src/coda/apps/fundingrequests/forms.py
+++ b/src/coda/apps/fundingrequests/forms.py
@@ -131,7 +131,7 @@ class PaymentForm(CodaFormBase):
 
     def to_dto(self) -> PaymentDto:
         return PaymentDto(
-            amount=float(self.cleaned_data["amount"]),
+            amount=self.cleaned_data["amount"],
             currency=self.cleaned_data["currency"],
             method=self.cleaned_data["method"],
             external_costsplitting=self.cleaned_data["external_costsplitting"],

--- a/src/coda/apps/fundingrequests/views/review.py
+++ b/src/coda/apps/fundingrequests/views/review.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
@@ -40,7 +42,7 @@ def process_review(fid: FundingRequestId, request: HttpRequest) -> None:
     action = request.POST["action"]
     review_result = action if action != "return" else ""
     dto = UpdateReviewDto(
-        decided_funding_amount=float(request.POST["decided_funding_amount"]),
+        decided_funding_amount=Decimal(request.POST["decided_funding_amount"]),
         decided_funding_currency=request.POST["decided_funding_currency"],
         reviewer_remarks=request.POST["reviewer_remarks"],
         result=review_result,

--- a/src/coda/contexts/fundingrequest/dto/commands.py
+++ b/src/coda/contexts/fundingrequest/dto/commands.py
@@ -7,6 +7,7 @@ test data builders and domain object conversion.
 
 import datetime
 from collections.abc import Iterable
+from decimal import Decimal
 from typing import Annotated
 
 from pydantic import AfterValidator, Field
@@ -37,13 +38,13 @@ class PaymentDto(CodaBaseDto):
     A serializable representation of a Payment object.
 
     Attributes:
-        estimated_cost (float): The estimated cost of the payment.
+        estimated_cost (Decimal): The estimated cost of the payment.
         currency_code: str
         method (str): The method of payment.
         external_costsplitting (bool | None): Whether external cost splitting occurred.
     """
 
-    amount: float
+    amount: Decimal
     currency: str
     method: str
     external_costsplitting: OptionalFromStr[bool] = None
@@ -51,7 +52,7 @@ class PaymentDto(CodaBaseDto):
     @classmethod
     def empty(cls) -> "PaymentDto":
         return PaymentDto(
-            amount=0,
+            amount=Decimal("0"),
             currency=Currency.EUR.code,
             method=PaymentMethod.Unknown.value,
         )
@@ -60,7 +61,7 @@ class PaymentDto(CodaBaseDto):
     def from_payment(cls, payment: Payment) -> "PaymentDto":
         """Creates a CostDto instance from a Payment object."""
         return cls(
-            amount=float(payment.amount.amount),
+            amount=payment.amount.amount,
             currency=payment.amount.currency.code,
             method=payment.method.value,
             external_costsplitting=payment.external_costsplitting,
@@ -138,7 +139,7 @@ class ExtraInformationDto(CodaBaseDto):
 
 
 class UpdateReviewDto(CodaBaseDto):
-    decided_funding_amount: float
+    decided_funding_amount: Decimal
     decided_funding_currency: str
     reviewer_remarks: str
     result: str

--- a/src/coda/contexts/fundingrequest/services/fundingrequests.py
+++ b/src/coda/contexts/fundingrequest/services/fundingrequests.py
@@ -356,7 +356,7 @@ def update_review(fundingrequest_id: FundingRequestId, review: UpdateReviewDto) 
     review_ = Review(
         fundingrequest_id,
         Money(
-            Decimal(review.decided_funding_amount),
+            review.decided_funding_amount,
             Currency.from_code(review.decided_funding_currency),
         ),
         remarks=review.reviewer_remarks,

--- a/src/coda/contexts/fundingrequest/services/import_service/_parsing.py
+++ b/src/coda/contexts/fundingrequest/services/import_service/_parsing.py
@@ -230,7 +230,7 @@ def parse_concept(import_dto: ConceptImportDto, lookups: ImportLookups) -> Conce
 def parse_cost_estimate(import_dto: CostEstimateImportDto) -> PaymentDto:
     """Parse cost estimate to payment DTO."""
     return PaymentDto(
-        amount=float(import_dto.amount),
+        amount=import_dto.amount,
         currency=import_dto.currency,
         method=import_dto.payment_method.value,
     )
@@ -270,7 +270,7 @@ def parse_extra_information(import_dto: FundingRequestImportDto) -> ExtraInforma
 def parse_review(import_dto: ReviewImportDto) -> CreateReviewDto:
     """Parse review DTO from import data."""
     return CreateReviewDto(
-        decided_funding_amount=float(import_dto.funding.amount),
+        decided_funding_amount=import_dto.funding.amount,
         decided_funding_currency=import_dto.funding.currency,
         reviewer_remarks=import_dto.remarks,
         result=import_dto.result.value,


### PR DESCRIPTION
Monetary values like 1234.56 are stored imprecisely when passed through a float. Every amount originated as a precise value but was converted to float at the DTO boundary, introducing tiny rounding errors into financial data.

Changes PaymentDto.amount and UpdateReviewDto.decided_funding_amount from float to Decimal, removes the float() casts at all 5 call sites, and fixes wizard serialization (model_dump(mode="python") + Decimal -> str) to preserve precision through the session store.

fixes #242 