### PR TITLE
Fix/blazing binary pre release issues

### DIFF
--- a/src/coda/apps/templates/fundingrequests/funders/detail.html
+++ b/src/coda/apps/templates/fundingrequests/funders/detail.html
@@ -27,7 +27,7 @@
                 <strong>Status:</strong> Active
             </p>
         {% endif %}
-        {% if object.links.all %}
+        {% if object.get_links %}
             <section class="my-2">
                 <h3>Identifiers</h3>
                 <table>
@@ -38,10 +38,12 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for link in object.links.all %}
+                        {% for link in object.get_links %}
                             <tr>
-                                <td>{{ link.type.name }}</td>
-                                <td>{{ link.value }}</td>
+                                <td>{{ link.type }}</td>
+                                <td>
+                                    <a href="{{ link.url }}">{{ link.value }}</a>
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/src/coda/apps/templates/fundingrequests/funders/overlap_detection_dialog.html
+++ b/src/coda/apps/templates/fundingrequests/funders/overlap_detection_dialog.html
@@ -8,13 +8,15 @@
             {% for org in overlapping_orgs %}
                 <li>
                     <strong>{{ org.name }}</strong>
-                    {% if org.links.all %}
-                        <ul>
-                            {% for link in org.links.all %}<li>{{ link.type.name }}: {{ link.value }}</li>{% endfor %}
-                        </ul>
-                    {% endif %}
-                    <a href="{% url 'fundingrequests:funder_merge_preview' pk=source.pk target_pk=org.pk %}"
-                       class="primary">Merge into {{ org.name }}</a>
+                    <div class="flex align-center justify-between">
+                        {% if org.links.all %}
+                            <ul>
+                                {% for link in org.links.all %}<li>{{ link.type.name }}: {{ link.value }}</li>{% endfor %}
+                            </ul>
+                        {% endif %}
+                        <a href="{% url 'fundingrequests:funder_merge_preview' pk=source.pk target_pk=org.pk %}"
+                           class="button outline">Merge</a>
+                    </div>
                 </li>
             {% endfor %}
         </ul>

--- a/src/coda/contexts/fundingrequest/services/doi_import/doi_client/_crossref/_fetch_publications_batch.py
+++ b/src/coda/contexts/fundingrequest/services/doi_import/doi_client/_crossref/_fetch_publications_batch.py
@@ -67,13 +67,10 @@ def fetch_publications_batch(
 
     # Safety cap: at most one item per requested DOI can match,
     # so len(dois) pages is a generous upper bound.
-    try:
-        items = _fetch_all_pages(client, params, len(dois), timeout)
-    except Exception as e:
-        return {str(doi): map_to_doi_error(e, doi) for doi in dois}
+    items, error = _fetch_all_pages(client, params, len(dois), timeout)
 
     found = _parse_batch_items(items)
-    return _build_batch_results(dois, found)
+    return _build_batch_results(dois, found, error)
 
 
 def _fetch_all_pages(
@@ -81,25 +78,31 @@ def _fetch_all_pages(
     params: dict[str, str | int],
     max_pages: int,
     timeout: int,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], Exception | None]:
     """Fetch all pages of batch data from Crossref.
 
     Iterates through cursor-based pagination up to *max_pages* calls.
-    Raises on HTTP or network error; the caller maps the exception
-    to per-DOI error results.
+
+    Returns a tuple of ``(items, error)``. If a page fails after earlier pages
+    succeeded, the items already collected are preserved and the error is
+    returned alongside them, so the caller can still resolve the DOIs found on
+    earlier pages instead of failing the entire batch.
     """
     all_items: list[dict[str, Any]] = []
     for _ in range(max_pages):
-        response = client.get(
-            CROSSREF_API_BASE,
-            params=params,
-            timeout=timeout,
-            follow_redirects=True,
-        ).raise_for_status()
+        try:
+            response = client.get(
+                CROSSREF_API_BASE,
+                params=params,
+                timeout=timeout,
+                follow_redirects=True,
+            ).raise_for_status()
+        except Exception as e:
+            return all_items, e
         data = response.json()
 
         message = data.get("message", {})
-        items = message.get("items", [])
+        items: list[Any] = message.get("items", [])
         if not items:
             break
         all_items.extend(items)
@@ -109,7 +112,7 @@ def _fetch_all_pages(
             break
         params["cursor"] = next_cursor
 
-    return all_items
+    return all_items, None
 
 
 def _parse_batch_items(
@@ -134,17 +137,21 @@ def _parse_batch_items(
 def _build_batch_results(
     dois: Sequence[Doi],
     found: dict[str, ExternalPublicationMetadata],
+    error: Exception | None = None,
 ) -> dict[str, ExternalPublicationMetadata | Exception]:
     """Build the final result dict for every requested DOI.
 
-    DOIs present in *found* get their metadata; missing DOIs get a
-    :class:`DOINotFoundError`.
+    DOIs present in *found* get their metadata. Missing DOIs get a
+    :class:`DOINotFoundError`, unless a page failed partway through the batch
+    (``error`` is set), in which case they get the mapped error instead.
     """
     results: dict[str, ExternalPublicationMetadata | Exception] = {}
     for doi in dois:
         doi_str = str(doi)
         if doi_str in found:
             results[doi_str] = found[doi_str]
+        elif error is not None:
+            results[doi_str] = map_to_doi_error(error, doi)
         else:
             results[doi_str] = DOINotFoundError(doi)
     return results

--- a/src/coda/domain/publication/links.py
+++ b/src/coda/domain/publication/links.py
@@ -563,6 +563,11 @@ class CrossrefId:
         return self._value
 
     def url(self) -> str:
+        # FIXME: this is actually incorrect.
+        # This DOI prefix only works for the crossref funder registry.
+        # In CODA this currently does not pose a problem,
+        # because CrossrefId is only used by FundingOrganization right now.
+        # However, it needs to be fixed ASAP by making the CrossrefId type more specific.
         return f"https://doi.org/10.13039/{self._value}"
 
     def __str__(self) -> str:

--- a/src/coda/domain/publication/links.py
+++ b/src/coda/domain/publication/links.py
@@ -152,6 +152,7 @@ class Doi:
             .removeprefix("https://")
             .removeprefix("http://")
             .removeprefix("doi.org/")
+            .removesuffix("/")
         )
         if not self._valid():
             raise InvalidDoi()

--- a/src/coda/domain/publication/links.py
+++ b/src/coda/domain/publication/links.py
@@ -145,7 +145,14 @@ class Doi:
     __match_args__ = ("_doi",)
 
     def __init__(self, doi: str) -> None:
-        self._doi = NonEmptyStr(doi).strip()
+        self._doi = (
+            NonEmptyStr(doi)
+            .strip()
+            .lower()
+            .removeprefix("https://")
+            .removeprefix("http://")
+            .removeprefix("doi.org/")
+        )
         if not self._valid():
             raise InvalidDoi()
 

--- a/tests/contexts/fundingrequest/test_crossref_batch_fetch.py
+++ b/tests/contexts/fundingrequest/test_crossref_batch_fetch.py
@@ -9,6 +9,9 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+import httpx
+import pytest
+
 from coda.contexts.fundingrequest.dto.external_metadata import ExternalPublicationMetadata
 from coda.contexts.fundingrequest.services.doi_import.doi_client import crossref
 from coda.contexts.fundingrequest.services.doi_import.doi_client.errors import DOINotFoundError
@@ -194,10 +197,10 @@ class TestCrossrefBatchPagination:
         for doi in dois:
             assert isinstance(result[str(doi)], Exception), f"{doi} should be an error"
 
-    def test__fetch_publications_batch__http_error_on_second_page__aborts_entire_batch(
+    def test__fetch_publications_batch__http_error_on_second_page__keeps_first_page_results(
         self,
     ) -> None:
-        """Given first page succeeds but second page fails, the whole batch returns errors."""
+        """Given first page succeeds but second page fails, first-page results are kept."""
         dois = [Doi(f"10.1234/paginate.{i}") for i in range(3)]
         page1_items = [_make_item(str(d)) for d in dois]
 
@@ -210,8 +213,42 @@ class TestCrossrefBatchPagination:
         )
 
         assert_pages_requested(fake_client, 2)
-        for doi in dois + [Doi("10.1234/extra")]:
-            assert isinstance(result[str(doi)], Exception), f"{doi} should be an error"
+        assert_all_found(result, dois)
+        assert isinstance(result["10.1234/extra"], Exception)
+
+
+class TestCrossrefBatchTrailingSlash:
+    """Tests for how DOIs with trailing slashes are handled.
+
+    A DOI with a trailing slash (e.g. ``10.1038/nature12373/``) is a distinct
+    DOI from the canonical form (``10.1038/nature12373``). It is not registered
+    in Crossref, so it must be reported as not found rather than silently
+    resolved to the canonical DOI's metadata.
+    """
+
+    @pytest.mark.parametrize(
+        "http_client",
+        [
+            pytest.param(
+                FakeHttpxClient(FakeHttpxResponse([_make_item("10.1038/nature12373")])),
+                id="fake-client",
+            ),
+            pytest.param(httpx, id="real-crossref-api", marks=pytest.mark.integration),
+        ],
+    )
+    def test__fetch_publications_batch__doi_with_trailing_slash__is_not_found(
+        self, http_client: Any
+    ) -> None:
+        """Given a DOI with a trailing slash, it is a distinct DOI and reported
+        as not found.
+
+        Uses a real, registered DOI (10.1038/nature12373) with a trailing slash
+        appended, so the same scenario is verifiable against the live API.
+        """
+        doi = Doi("10.1038/nature12373/")
+        result = crossref.fetch_publications_batch([doi], http_client=http_client)
+
+        assert isinstance(result[str(doi)], DOINotFoundError)
 
 
 class TestCrossrefBatchWithRealData:

--- a/tests/domain/test_doi.py
+++ b/tests/domain/test_doi.py
@@ -41,3 +41,18 @@ def test__doi__url__returns_url() -> None:
     sut = Doi("10.1234/foobar")
 
     assert sut.url() == f"https://doi.org/{sut}"
+
+
+@pytest.mark.parametrize("protocol", ["https", "http"])
+def test__doi_from_url__strips_doi_org_domain(protocol: str) -> None:
+    sut = Doi(f"{protocol}://doi.org/10.1234/0000/9485")
+
+    assert sut == Doi("10.1234/0000/9485")
+
+
+def test__dois_are_case_insensitive() -> None:
+    first = Doi("10.1234/foobar")
+    second = Doi("10.1234/FoObAR")
+
+    assert first == second
+    assert first.value() == second.value() == "10.1234/foobar"

--- a/tests/domain/test_doi.py
+++ b/tests/domain/test_doi.py
@@ -56,3 +56,10 @@ def test__dois_are_case_insensitive() -> None:
 
     assert first == second
     assert first.value() == second.value() == "10.1234/foobar"
+
+
+def test__doi_with_trailing_slash__strips_slash() -> None:
+    sut = Doi("10.1234/1234/")
+    expected = Doi("10.1234/1234")
+
+    assert sut == expected


### PR DESCRIPTION
# Changes
1. fix(Doi): allow extracting doi from url. store internally as lowercase The Doi value object now accepts full URLs (e.g. https://doi.org/10.1234/foo) and strips the protocol and domain down to just the DOI. Storage is normalized to lowercase, making DOIs case-insensitive for comparison (Doi("10.1234/Foo") == Doi("10.1234/foo")).

2. fix(crossref): prevent http errors from poisoning entire doi import When fetching a batch of DOIs from Crossref, an HTTP error on a later page used to abort the entire batch, discarding results already fetched from earlier pages. Now partial results are preserved — DOIs found before the error are resolved correctly, while only the unresolved DOIs are marked with the error.

3. fix(Doi): Doi value object strips trailing slash A DOI with a trailing slash (e.g. 10.1038/nature12373/) is a distinct, unregistered DOI and must not silently resolve to the canonical form. The Doi class now strips trailing slashes, and the batch fetcher verifies this against both the fake test client and the real Crossref API.