### PR TITLE
fix(opencost): add missing values to ContractCostType enum

### DIFF
--- a/src/coda/domain/opencost/_types.py
+++ b/src/coda/domain/opencost/_types.py
@@ -1,8 +1,4 @@
-"""Basic type definitions for OpenCost domain models.
-
-This module contains simple type aliases and enums that don't depend on other OpenCost modules,
-preventing circular import issues.
-"""
+"""Basic type definitions for OpenCost domain models."""
 from enum import Enum
 from typing import Annotated
 from pydantic import StringConstraints
@@ -14,12 +10,16 @@ DateFormat = Annotated[str, StringConstraints(pattern=r"[0-9]{4}(-[0-9]{2}){0,2}
 
 
 class ContractCostType(Enum):
+    """OpenCost contract_cost_type"""
     publish = "publish"
     read = "read"
+    publish_and_read = "publish and read"
+    service_fee = "service fee"
     vat = "vat"
 
 
 class PublicationCostType(Enum):
+    """OpenCost publication_cost_type"""
     gold_oa = "gold-oa"
     vat = "vat"
     colour_charge = "colour charge"


### PR DESCRIPTION
`ContractCostType` was missing some values. Should fix error on export.

<img width="1325" height="715" alt="image" src="https://github.com/user-attachments/assets/6eca14b9-3c48-4ef3-8c53-6d5b8c88d72b" />
 

https://github.com/opencost-de/opencost/blob/af6d257c0ad2604043d7a9971f40283ff77ab3fb/doc/opencost_types.xsd#L296